### PR TITLE
extract user reference from the token

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -16,6 +16,7 @@ apply plugin: "org.unbroken-dome.test-sets"
 dependencies {
     compile("org.springframework.boot:spring-boot-starter-web")
     compile project(':model')
+    compile("com.auth0:java-jwt:3.2.0")
     testCompile("org.springframework.restdocs:spring-restdocs-core:${restDocsVersion}")
     testCompile("org.springframework.restdocs:spring-restdocs-mockmvc:${restDocsVersion}")
 }

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -16,7 +16,7 @@ apply plugin: "org.unbroken-dome.test-sets"
 dependencies {
     compile("org.springframework.boot:spring-boot-starter-web")
     compile project(':model')
-    compile("com.auth0:java-jwt:3.2.0")
+    compile("org.bitbucket.b_c:jose4j:0.5.2")
     testCompile("org.springframework.restdocs:spring-restdocs-core:${restDocsVersion}")
     testCompile("org.springframework.restdocs:spring-restdocs-mockmvc:${restDocsVersion}")
 }

--- a/service/src/main/java/uk/ac/ebi/tsc/aap/client/repo/TokenService.java
+++ b/service/src/main/java/uk/ac/ebi/tsc/aap/client/repo/TokenService.java
@@ -1,9 +1,11 @@
 package uk.ac.ebi.tsc.aap.client.repo;
 
-import com.auth0.jwt.JWT;
-import com.auth0.jwt.interfaces.DecodedJWT;
+import org.apache.tomcat.util.codec.binary.StringUtils;
+import org.jose4j.jwt.JwtClaims;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.Base64;
 
 /**
  * Created by ukumbham on 21/09/2017.
@@ -23,12 +25,13 @@ public class TokenService {
     }
 
     public String getUserReference(String token) {
-        String userReference = null;
-
-        DecodedJWT decodedJwt = JWT.decode(token);
-        userReference = decodedJwt.getSubject();
-
-        return userReference;
+        try {
+            String base64Payload = token.split("\\.")[1];
+            String payload = StringUtils.newStringUtf8(Base64.getDecoder().decode(base64Payload));
+            return JwtClaims.parse(payload).getSubject();
+        } catch (Throwable t) {
+            throw new RuntimeException("Error while getting user reference", t);
+        }
     }
 
 }

--- a/service/src/main/java/uk/ac/ebi/tsc/aap/client/repo/TokenService.java
+++ b/service/src/main/java/uk/ac/ebi/tsc/aap/client/repo/TokenService.java
@@ -1,5 +1,7 @@
 package uk.ac.ebi.tsc.aap.client.repo;
 
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.interfaces.DecodedJWT;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -12,12 +14,21 @@ public class TokenService {
     private TokenRepository tokenServiceRepo;
 
     @Autowired
-    public TokenService(TokenRepository tokenServiceRepo){
+    public TokenService(TokenRepository tokenServiceRepo) {
         this.tokenServiceRepo = tokenServiceRepo;
     }
 
-    public String getAAPToken(String username,String password){
-       return tokenServiceRepo.getAAPToken(username,password);
+    public String getAAPToken(String username, String password) {
+        return tokenServiceRepo.getAAPToken(username, password);
+    }
+
+    public String getUserReference(String token) {
+        String userReference = null;
+
+        DecodedJWT decodedJwt = JWT.decode(token);
+        userReference = decodedJwt.getSubject();
+
+        return userReference;
     }
 
 }

--- a/service/src/test/java/uk/ac/ebi/tsc/aap/client/repo/TokenServiceTest.java
+++ b/service/src/test/java/uk/ac/ebi/tsc/aap/client/repo/TokenServiceTest.java
@@ -1,24 +1,18 @@
 package uk.ac.ebi.tsc.aap.client.repo;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(classes = TokenService.class)
 public class TokenServiceTest {
 
-    @Autowired
     private TokenService tokenService;
 
-    @MockBean
-    private TokenRepository tokenRepository;
+    public TokenServiceTest() {
+        tokenService = new TokenService(mock(TokenRepository.class));
+    }
 
     @Test
     public void can_get_user_ref_from_token(){

--- a/service/src/test/java/uk/ac/ebi/tsc/aap/client/repo/TokenServiceTest.java
+++ b/service/src/test/java/uk/ac/ebi/tsc/aap/client/repo/TokenServiceTest.java
@@ -1,0 +1,46 @@
+package uk.ac.ebi.tsc.aap.client.repo;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = TokenService.class)
+public class TokenServiceTest {
+
+    @Autowired
+    private TokenService tokenService;
+
+    @MockBean
+    private TokenRepository tokenRepository;
+
+    @Test
+    public void can_get_user_ref_from_token(){
+        //this is the example token from https://jwt.io/
+        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.XbPfbIHMI6arZ3Y922BhjWgQzWXcXNrz0ogtVhfEd2o";
+        String expectedUserReference = "1234567890";
+
+        String actualUserReference = tokenService.getUserReference(token);
+
+        assertThat(actualUserReference, equalTo(expectedUserReference));
+    }
+
+    @Test
+    public void get_null_when_user_ref_absent(){
+        //this is the example token from https://jwt.io/, but with the subject deleted
+        String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE1MTYyMzkwMjJ9.8nYFUX869Y1mnDDDU4yL11aANgVRuifoxrE8BHZY1iE";
+
+        String actualUserReference = tokenService.getUserReference(token);
+
+        assertThat(actualUserReference, nullValue());
+    }
+
+}
+
+


### PR DESCRIPTION
Added support for extracting user references from a token in Token Service. Using auth0’s parser, as it’s simpler than jose for basic cases like this, where we don’t need to worry about full validation