### PR TITLE
expose real errors when fetching token

### DIFF
--- a/service/src/main/java/uk/ac/ebi/tsc/aap/client/exception/UserNameOrPasswordWrongException.java
+++ b/service/src/main/java/uk/ac/ebi/tsc/aap/client/exception/UserNameOrPasswordWrongException.java
@@ -5,7 +5,7 @@ package uk.ac.ebi.tsc.aap.client.exception;
  * Responsible to throw custom error message to the user
  */
 public class UserNameOrPasswordWrongException extends RuntimeException {
-    public UserNameOrPasswordWrongException(String message){
-        super(message);
+    public UserNameOrPasswordWrongException(String message,Exception e){
+        super(message,e);
     }
 }

--- a/service/src/main/java/uk/ac/ebi/tsc/aap/client/repo/TokenRepositoryRest.java
+++ b/service/src/main/java/uk/ac/ebi/tsc/aap/client/repo/TokenRepositoryRest.java
@@ -48,10 +48,10 @@ public class TokenRepositoryRest implements TokenRepository {
                                                 HttpMethod.GET, entity, String.class);
         }
         catch (HttpClientErrorException e){
-         throw new UserNameOrPasswordWrongException(String.format("username/password wrong. Please check username or password to get token"));
+         throw new UserNameOrPasswordWrongException(String.format("username/password wrong. Please check username or password to get token"),e);
         }
         catch (Exception e){
-            throw new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new RuntimeException("Error while getting AAP token",e);
         }
         return response.getBody();
     }

--- a/service/src/test/java/uk/ac/ebi/tsc/aap/client/repo/TokenRepositoryRestTest.java
+++ b/service/src/test/java/uk/ac/ebi/tsc/aap/client/repo/TokenRepositoryRestTest.java
@@ -46,7 +46,7 @@ public class TokenRepositoryRestTest {
         assertThat(token, notNullValue());
     }
 
-    @Test(expected = HttpServerErrorException.class)
+    @Test(expected = RuntimeException.class)
     public void should_return_error_while_retrieving_token_on_server() {
         this.domainsApi.expect(requestTo("/auth")).andExpect(method(HttpMethod.GET))
                 .andRespond(withServerError());


### PR DESCRIPTION
The client currently swallows errors when fetching a token. This PR ensure the root cause is exposed, which should make it easier to debug problems.